### PR TITLE
Possible NaN because a collision event is missed!

### DIFF
--- a/src/Agent.cs
+++ b/src/Agent.cs
@@ -153,7 +153,7 @@ namespace RVO
 
                     continue;
                 }
-                else if (s >= 0.0f && s < 1.0f && distSqLine <= radiusSq)
+                else if (s >= 0.0f && s <= 1.0f && distSqLine <= radiusSq)
                 {
                     /* Collision with obstacle segment. */
                     line.point = new Vector2(0.0f, 0.0f);


### PR DESCRIPTION
In Agent.cpp when obstacle ORCA lines are created there can be the case where 's' is exactly 1 we can miss a collision (distSqLine < radiusSq == true) and this causes 'leg' to become NaN later when the square-root of a negative is computed. We can't skip collision detection just because 's' is 1 so we should either go into the middle or last branch. Both computes the same result but the last branch is faster.